### PR TITLE
Fix uberjar build

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -108,10 +108,12 @@
                        :env {:production true}
                        :omit-source true
                        :aot :all
-                       :cljsbuild {:builds 
-                                   {:uberjar {:source-paths ["src/cljs" "env/prod/cljs"]
-                                              :compiler {:output-to "resources/public/js/app.js"
-                                                         :output-dir "resources/public/js/advanced"
-                                                         :source-map "resources/public/js/app.js.map"
-                                                         :optimizations :advanced
-                                                         :pretty-print false}}}}}})
+                       :cljsbuild ^:replace
+                       {:builds
+                        {:uberjar {:source-paths ["src/cljs" "env/prod/cljs"]
+                                   :compiler {:output-to "resources/public/js/app.js"
+                                              :output-dir "resources/public/js/advanced"
+                                              :source-map "resources/public/js/app.js.map"
+                                              :main onyx-dashboard.dev
+                                              :optimizations :advanced
+                                              :pretty-print false}}}}}})

--- a/src/clj/onyx_dashboard/http/server.clj
+++ b/src/clj/onyx_dashboard/http/server.clj
@@ -89,7 +89,8 @@
             tracking (atom {})
             event-handler-fut (start-event-handler sente peer-config deployments tracking)
             handler (ring.middleware.defaults/wrap-defaults routes ring-defaults-config)
-            server (http-kit-server/run-server handler {:port 3000})
+            port (Integer. (or (System/getenv "PORT") "3000"))
+            server (http-kit-server/run-server handler {:port port})
             uri (format "http://localhost:%s/" (:local-port (meta server)))
             refresh-fut (future (od/refresh-deployments-watch send-f 
                                                               (zk/connect (:zookeeper/address peer-config))


### PR DESCRIPTION
Without replacing cljsbuild was using first one, which was `:app`, and built incomplete app.js. With that change we get onyx-dashboard.jar with advanced-compiled app.js.

I guess port thing is pretty obvious. :)