### PR TITLE
Update docker run command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ By default the server will listen on port 3000, but this can be configured via t
 
 Alternately, run the docker image like so:
 ```
-git@github.com:drewverlee/onyx-dashboard.git
+docker run -p 3000:3000 onyx/onyx-dashboard:latest "192.168.1.170:2188"
 ```
 
 The IP passed in is used by ZooKeeper.

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ By default the server will listen on port 3000, but this can be configured via t
 
 Alternately, run the docker image like so:
 ```
-docker run -e ZOOKEEPER_ADDR="192.168.1.170:2188" onyx/onyx-dashboard:tag
+git@github.com:drewverlee/onyx-dashboard.git
 ```
+
+The IP passed in is used by ZooKeeper.
 
 ## Development
 


### PR DESCRIPTION
The current command in the readme results in a wrong number of arguments error. This corrects that but their can probably be some clarity around why we need to pass in a IP for zookeeper. I would guess its because of differences in environments, but i can't be sure.

With this change i still cannot manage to get the dashboard running however.

1. fire up a repl in the starter project https://github.com/onyx-platform/onyx-starter
2. run (user/go) and (require 'onyx-starter.launcher.submit-sample-job)
3. run docker run -p 3000:3000 onyx/onyx-dashboard:latest "192.168.1.170:2188"
4. visit localhost:3000
5. site cannot be reached
