### PR TITLE
Handle ZK connection state and show in the Dashboard

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
 
                  ; onyx deps
                  ^{:voom {:repo "git@github.com:onyx-platform/onyx.git" :branch "master"}}
-                 [org.onyxplatform/onyx "0.9.12"]
+                 [org.onyxplatform/onyx "0.9.12"       :exclusions [org.slf4j/slf4j-nop]]
                  [org.onyxplatform/lib-onyx "0.9.10.0" :exclusions [ring-jetty-component org.onyxplatform/onyx]]
                  [org.onyxplatform/onyx-visualization "0.4.0"]
 

--- a/src/clj/onyx_dashboard/channels.clj
+++ b/src/clj/onyx_dashboard/channels.clj
@@ -1,0 +1,25 @@
+(ns onyx-dashboard.channels
+  (:require [clojure.core.async :refer [close! chan]]
+            [com.stuartsierra.component :as component]))
+
+; Responsibilities
+; - hold channels
+; Useable to make duplex comunication between components
+; CompA -> chan1 -> CompB
+; CompB <- chan2 <- CompB
+(defrecord Channels []
+  component/Lifecycle
+  (start [component]
+    (println "Starting Channels")
+    (let [cmds-deployments-ch (chan 100)]
+
+      (assoc component
+        :cmds-deployments-ch cmds-deployments-ch)))
+
+  (stop [{:keys [cmds-deployments-ch] :as component}]
+    (println "Stopping Channels")
+    (when cmds-deployments-ch (close! cmds-deployments-ch))
+    (assoc component :cmds-deployments-ch nil)))
+
+(defn new-channels []
+  (map->Channels {}))

--- a/src/clj/onyx_dashboard/http/deployments.clj
+++ b/src/clj/onyx_dashboard/http/deployments.clj
@@ -1,0 +1,91 @@
+(ns onyx-dashboard.http.deployments
+  (:require [clojure.core.async :refer [close! chan go-loop <!]]
+            [com.stuartsierra.component :as component]
+            [onyx.log.curator           :as zk]
+            [onyx.log.zookeeper         :as zk-onyx]))
+
+(defn zk-deployment-entry-stat [zk-client entry]
+  (:stat (zk/data zk-client (zk-onyx/prefix-path entry))))
+
+(defn distribute-deployment-listing [send-all-fn! listing]
+  (send-all-fn! [:deployment/listing listing]))
+
+; stops when ZK unreachable
+(defn deployments-watch [send-all-fn! zk-client deployments]
+  (try
+    (loop []
+      (if-not (Thread/interrupted)
+        (try
+          (if-let [children (zk/children zk-client zk-onyx/root-path)]
+            (do (->> children
+                     (map (juxt identity
+                                (partial zk-deployment-entry-stat zk-client)))
+                     (map (fn [[child stat]]
+                            (vector child
+                                    {:created-at  (java.util.Date. (:ctime stat))
+                                     :modified-at (java.util.Date. (:mtime stat))})))
+                     (into {})
+                     (reset! deployments)
+                     (distribute-deployment-listing send-all-fn!))
+                (Thread/sleep 1000))
+            (do
+              (println (format "Could not find deployments at %s. Retrying in 1s." zk-onyx/root-path))
+              (Thread/sleep 1000)))
+          ; if we connected to early try again
+          (catch org.apache.zookeeper.KeeperException$NoNodeException e
+                 (do
+                   (println (format "Could not find deployments at %s. Retrying in 1s." zk-onyx/root-path))
+                   (Thread/sleep 1000)))))
+      (recur))
+    (catch java.lang.IllegalStateException e)
+    (catch org.apache.zookeeper.KeeperException$ConnectionLossException e
+      (println (format "ZK connection lost at %s. Deployments watch stopped." zk-onyx/root-path)))
+    (catch Throwable t
+      (println "Error :" t))
+    )
+  )
+
+(defn start-deployments-watch [sente zk deployments]
+  (future (deployments-watch (-> sente :send-mult)
+                             (-> zk    :zk-client)
+                             deployments)))
+; Responsibilities
+; - watch for deployments
+; - restart watch after zk reconnected
+(defrecord Deployments []
+  component/Lifecycle
+  (start [{:keys [channels sente zk] :as component}]
+    (println "Starting Deployments")
+    (let [into-br (-> sente :chsk-send!)
+          cmds-ch (-> channels :cmds-deployments-ch)
+          deployments       (atom {})
+          deployments-watch (start-deployments-watch sente zk deployments)
+          cmds (go-loop []
+                        (when-let [[cmd data] (<! cmds-ch)]
+                               (do (case cmd
+                                     :deployment/listing
+                                      (let [user-id  (-> data :user-id)]
+                                        (into-br user-id [:deployment/listing @deployments]))
+
+                                      :restart
+                                      (do (when deployments-watch (future-cancel deployments-watch))
+                                          (assoc component
+                                            :deployments-watch (start-deployments-watch sente zk deployments))))
+                                   (recur))))]
+      (assoc component
+        :deployments       deployments
+        :deployments-watch deployments-watch
+        :cmds              cmds)))
+
+  (stop [{:keys [deployments-watch cmds] :as component}]
+    (println "Stopping Deployments")
+
+    (when cmds              (close! cmds))
+    (when deployments-watch (future-cancel deployments-watch))
+
+    (assoc component :cmds              nil
+                     :deployments       nil
+                     :deployments-watch nil)))
+
+(defn new-deployments []
+  (map->Deployments {}))

--- a/src/clj/onyx_dashboard/http/sente.clj
+++ b/src/clj/onyx_dashboard/http/sente.clj
@@ -13,23 +13,41 @@
 
 (def packer (sente-transit/get-flexi-packer :edn))
 
+(defn send-mult-fn [send-fn! connected-uids msg]
+  (doseq [uid (:any @connected-uids)]
+    (send-fn! uid msg)))
+
+; Responsibilities
+; create websocket for backend
+; create functions for send/receive data via websocket
 (defrecord Sente []
   component/Lifecycle
   (start [component]
     (println "Starting Sente")
     (let [x (make-channel-socket!
              taoensso.sente.server-adapters.http-kit/http-kit-adapter
-             {:user-id-fn user-id-fn :packer packer})]
+             {:user-id-fn user-id-fn :packer packer})
+
+          ring-ajax-post                (-> x :ajax-post-fn)
+          ring-ajax-get-or-ws-handshake (-> x :ajax-get-or-ws-handshake-fn)
+          ch-chsk                       (-> x :ch-recv)
+          chsk-send!                    (-> x :send-fn)
+          connected-uids                (-> x :connected-uids)
+
+          send-mult (partial send-mult-fn
+                             chsk-send!
+                             connected-uids)]
       (assoc component
-        :ring-ajax-post (:ajax-post-fn x)
-        :ring-ajax-get-or-ws-handshake (:ajax-get-or-ws-handshake-fn x)
-        :ch-chsk (:ch-recv x)
-        :chsk-send! (:send-fn x)
-        :connected-uids (:connected-uids x))))
+        :ring-ajax-post ring-ajax-post
+        :ring-ajax-get-or-ws-handshake ring-ajax-get-or-ws-handshake
+        :ch-chsk        ch-chsk
+        :chsk-send!     chsk-send!
+        :connected-uids connected-uids
+        :send-mult      send-mult)))
 
   (stop [component]
     (println "Stopping Sente")
-    (close! (:ch-chsk component))
+    (close! (-> component :ch-chsk))
     (assoc component :server nil)))
 
 (defn sente []

--- a/src/clj/onyx_dashboard/http/zk_client.clj
+++ b/src/clj/onyx_dashboard/http/zk_client.clj
@@ -1,0 +1,211 @@
+(ns onyx-dashboard.http.zk-client
+  (:require [clojure.core.async :refer [chan timeout thread <!! >!! alts!! go-loop <! >! close! go]]
+            [com.stuartsierra.component :as component]
+            [onyx.log.curator :as zk]
+            [taoensso.timbre :as timbre :refer [info error spy]])
+  (:import [java.util.concurrent TimeUnit]
+           [org.apache.zookeeper CreateMode]
+           [org.apache.zookeeper
+            KeeperException
+            KeeperException$NoNodeException
+            KeeperException$NodeExistsException
+            KeeperException$Code
+            Watcher]
+           [org.apache.curator.test TestingServer]
+           [org.apache.zookeeper.data Stat]
+           [org.apache.curator.framework CuratorFrameworkFactory CuratorFramework]
+           [org.apache.curator.framework.api CuratorWatcher PathAndBytesable Versionable GetDataBuilder
+            SetDataBuilder DeleteBuilder ExistsBuilder GetChildrenBuilder Pathable Watchable]
+           [org.apache.curator.framework.state ConnectionStateListener ConnectionState]
+           [org.apache.curator.framework.imps CuratorFrameworkState]
+           [org.apache.curator RetryPolicy]
+           [org.apache.curator.retry RetryOneTime BoundedExponentialBackoffRetry]))
+  
+; connection with fail fast settings
+; retry only 1
+; try to connect up to 5s
+(defn ^CuratorFramework connect-1-retry
+  ([connection-string]
+   (connect-1-retry connection-string ""))
+  ([connection-string ns]
+   (connect-1-retry connection-string ns
+            (RetryOneTime. 5000)))
+  ([connection-string ns ^RetryPolicy retry-policy]
+   (doto
+       (.. (CuratorFrameworkFactory/builder)
+           (namespace ns)
+           (connectString connection-string)
+           (retryPolicy retry-policy)
+           (connectionTimeoutMs  5000)   ;  5s
+           (sessionTimeoutMs    10000)   ; 10s
+           (build))
+     .start)))
+
+(defn try-connect [zk-client]
+  (println "Trying connect ZK 5s ...")
+  (.. zk-client
+      (blockUntilConnected 5 TimeUnit/SECONDS)))
+
+; conn reconnect
+(defn until-connected [zk-client restart-ch]
+  (future (when-let [_ (<!! restart-ch)]
+                    (loop []
+                          (or (try-connect zk-client)
+                              (recur))))))
+
+(defn as-connection-listener [f]
+  (reify ConnectionStateListener
+    (stateChanged [_ zk-client newState]
+      (f newState))))
+
+(defn add-conn-watcher [zk-client listener-fn]
+  (let [listener (as-connection-listener listener-fn)]
+        (.. zk-client
+            getConnectionStateListenable
+            (addListener listener))
+        listener))
+
+(defn remove-conn-watcher [zk-client listener]
+  (println "Removing listener" listener)
+  (.. zk-client
+      getConnectionStateListenable
+      (removeListener listener)))
+
+; add conn listener and notify state change
+(defn notify-console [zk-client zk-state channels]
+  (add-conn-watcher zk-client 
+                    (fn [newState] 
+                        (println "ZK connection state:" (str newState))
+                        (reset! zk-state newState)
+
+                        (when (= newState ConnectionState/RECONNECTED)
+                              (go (>! (-> channels :cmds-deployments-ch) [:restart]))))))
+
+
+; send connection status into browser
+(defn zk-state->browser [into-br user-id newState] 
+  (let [msg (condp = newState
+                   ConnectionState/CONNECTED   {:zk-up? true}
+                   ConnectionState/RECONNECTED {:zk-up? true}
+                   ConnectionState/LOST        {:zk-up? false}
+                   nil)]
+        (when msg
+              (do 
+                (into-br user-id [:deployment/zk-conn-state msg])
+                (println "Notify browser that ZK conn:" (str newState))))))
+
+; add conn listener and notify state change
+(defn notify-browser [zk-client into-br user-id]
+  (add-conn-watcher zk-client 
+                    (fn [newState] 
+                        (zk-state->browser into-br user-id newState))))
+
+; needs restart on conn lost
+(defn notify-restarter [zk-client restart-ch]
+  (add-conn-watcher zk-client 
+                    (fn [newState]
+                        ; try connect in bg when connection lost 
+                        (when (= ConnectionState/LOST newState)
+                              (go (>! restart-ch true))))))
+                                        
+; Responsibilities
+; - watch Zookeeper connection
+; - notify browser about connection state
+; - notify console about connection state
+; - notify restarter to start trying reconnect
+; - notify to restart refresh-deployments-watch when connection reconnected
+(defrecord ZKClient [peer-config]
+  component/Lifecycle
+  (start [{:keys [channels sente] :as component}]
+    (println "Starting ZKClient")
+    (let [into-br (-> sente :chsk-send!)
+
+          ; ZK connection client
+          zk-client (connect-1-retry (:zookeeper/address peer-config))
+          zk-state (atom false)
+          ; show connection status on console
+          ; force other components to restart after reconnect
+          nc (notify-console zk-client zk-state channels)
+
+          ; try connect when connection lost
+          restarter-ch (chan 100)
+          restarter    (until-connected  zk-client restarter-ch)
+          nr           (notify-restarter zk-client restarter-ch)
+
+          ; show conn status on launched dashboards
+          nb (atom {})
+
+          ; react on events from other components
+          notify-zc-ch (chan 100)
+          notify-zc (go-loop []
+                        (when-let [[cmd data] (<! notify-zc-ch)]
+                          (do 
+                            (case cmd
+                                  :attach-browser-notify     
+                                  (let [user-id  (-> data :user-id)
+                                        ; attach notifier
+                                        listener (notify-browser zk-client into-br user-id)]
+                                        ; save listener to be able to remove it during close components phase
+                                        (swap! nb assoc (keyword user-id) listener)
+                                        ; send curent zk conn state into browser 
+                                        (zk-state->browser  into-br 
+                                                            user-id 
+                                                            @zk-state))
+                                  :remove-browser-notify
+                                  (let [user-id  (-> data :user-id keyword)
+                                        listener (-> @nb user-id)]
+                                        (when listener (remove-conn-watcher zk-client listener)))
+
+                                  :browser-refresh-zk-conn 
+                                  (let [user-id  (-> data :user-id keyword)]
+                                        (zk-state->browser into-br
+                                                           user-id
+                                                           @zk-state))
+
+                                  )
+                            (recur))))
+
+          ; try connect first time
+          ; keep retrying if failed
+          _ (or (try-connect     zk-client)
+                (>!! restarter-ch true))
+
+          ]
+          (assoc component
+                 :zk-client    zk-client
+                 :zk-state     zk-state
+                 :nc           nc
+                 :nb           nb
+                 :restarter-ch restarter-ch
+                 :restarter    restarter
+                 :nr           nr
+                 :notify-zc-ch notify-zc-ch  
+                 :notify-zc    notify-zc)))
+
+  (stop [{:keys [zk-client nc nb nr notify-zc-ch notify-zc restarter-ch restarter] :as component}]
+    (println "Stopping ZKClient")
+    (when notify-zc    (close! notify-zc))
+    (when notify-zc-ch (close! notify-zc-ch))
+    (when restarter-ch (close! restarter-ch))
+    (when restarter    (future-cancel restarter))
+
+    (when nc (remove-conn-watcher zk-client nc))
+    (when nr (remove-conn-watcher zk-client nr))
+
+    (when nb (doseq [nb_ (vals @nb)]
+                    (remove-conn-watcher zk-client nb_))) 
+    (reset! nb {})
+    (when (.. zk-client isStarted) 
+          (zk/close zk-client))
+    (assoc component  :zk-client    nil
+                      :zk-state     nil
+                      :nc           nil 
+                      :nb           nil
+                      :nr           nil
+                      :notify-zc-ch nil
+                      :notify-zc    nil
+                      :restarter-ch nil 
+                      :restarter    nil)))
+
+(defn new-zk-client [peer-config]
+  (map->ZKClient {:peer-config peer-config}))

--- a/src/clj/onyx_dashboard/system.clj
+++ b/src/clj/onyx_dashboard/system.clj
@@ -3,8 +3,11 @@
             [clojure.tools.namespace.repl :refer [refresh]]
             [com.stuartsierra.component :as component]
             [onyx-dashboard.dev :refer [is-dev? inject-devmode-html #_browser-repl start-figwheel]]
-            [onyx-dashboard.http.sente :refer [sente]]
-            [onyx-dashboard.http.server :refer [new-http-server]]
+            [onyx-dashboard.http.sente       :refer [sente]]
+            [onyx-dashboard.http.server      :refer [new-http-server]]
+            [onyx-dashboard.http.zk-client   :refer [new-zk-client]]
+            [onyx-dashboard.http.deployments :refer [new-deployments]]
+            [onyx-dashboard.channels         :refer [new-channels]]
             [onyx.system :refer [onyx-client]]
             [onyx.messaging.aeron]
             [compojure.core :refer [GET defroutes]]
@@ -16,31 +19,39 @@
             [environ.core :refer [env]]
             [onyx.static.validation :refer [validate-peer-config]]
             [clojure.string :refer [upper-case]]
-            [taoensso.timbre :as timbre]
+            [taoensso.timbre :refer [info] :as timbre]
             [taoensso.timbre.appenders.3rd-party.rotor :as rotor])
   (:gen-class))
 
 
 (defn get-system 
   ([zookeeper-addr]
-    (let [file-log-lvl    :error   ; set to :trace to see more details
-          console-log-lvl :info
-          rotor-appender (rotor/rotor-appender {:path "dashboard.log"})
-          rotor-appender (assoc rotor-appender :min-level file-log-lvl)]
-          (timbre/merge-config!
-              {:appenders
-                {:println {:min-level console-log-lvl
-                           :enabled? true}
-                 :rotor rotor-appender}}))
+    (let [file-log-lvl   :error  ; set to :trace to see more details
+         console-log-lvl :info
+         rotor-appender (rotor/rotor-appender {:path "dashboard.log"})
+         rotor-appender (assoc rotor-appender :min-level file-log-lvl)]
+         (timbre/merge-config!
+            {:appenders
+              {:println {:min-level console-log-lvl
+                         :enabled? true}
+               :rotor rotor-appender}}))
+    (println "=================================")
+    (println "Starting Dashboard components ...")
    (component/system-map
-     :sente (component/using (sente) [])
+     :channels (component/using (new-channels) [])
+     :sente    (component/using (sente) [])
+     :zk (component/using (new-zk-client {:zookeeper/address zookeeper-addr
+                                          ;; Remove once schema is fixed
+                                          :onyx.peer/job-scheduler :not-required/for-peer-sub})
+                          [:channels :sente])
+     :deployments (component/using (new-deployments) [:channels :sente :zk])
      :http (component/using (new-http-server {:zookeeper/address zookeeper-addr
                                               ;; Remove once schema is fixed
                                               :onyx.peer/job-scheduler :not-required/for-peer-sub
                                               :onyx.messaging/impl :aeron
                                               ;; Doesn't matter for the dashboard
                                               :onyx.messaging/bind-addr "localhost"}) 
-                            [:sente]))))
+                            [:channels :sente :zk :deployments]))))
 
 (defn -main [zookeeper-addr]
   (component/start (get-system zookeeper-addr))

--- a/src/clj/onyx_dashboard/tenancy.clj
+++ b/src/clj/onyx_dashboard/tenancy.clj
@@ -5,7 +5,7 @@
             [onyx.log.zookeeper :as zk-onyx]
             [onyx.log.commands.common :as common]
             [onyx.log.curator :as zk]
-            [clojure.core.async :refer [chan timeout thread <!! alts!!]]
+            [clojure.core.async :refer [chan timeout thread <!! alts!! go-loop close! <!]]
             [com.stuartsierra.component :as component]
 	    [lib-onyx.log-subscriber :as s]
             [lib-onyx.job-query :as jq]
@@ -26,37 +26,10 @@
   (kill-job peer-config deployment-id job-info)
   (start-job peer-config deployment-id job-info))
 
-(defn zk-deployment-entry-stat [client entry]
-  (:stat (zk/data client (zk-onyx/prefix-path entry))))
 
-(defn distribute-deployment-listing [send-all-fn! listing]
-  (send-all-fn! [:deployment/listing listing]))
+(defn deployment-pulses [zk-client deployment-id]
+  (zk/children zk-client (zk-onyx/pulse-path deployment-id)))
 
-(defn deployment-pulses [client deployment-id]
-  (zk/children client (zk-onyx/pulse-path deployment-id)))
-
-(defn refresh-deployments-watch [send-all-fn! zk-client deployments]
-  (try 
-    (loop [] 
-      (when-not (Thread/interrupted)
-        (if-let [children (zk/children zk-client zk-onyx/root-path)]
-          (do (->> children
-                   (map (juxt identity 
-                              (partial zk-deployment-entry-stat zk-client)))
-                   (map (fn [[child stat]]
-                          (vector child
-                                  {:created-at (java.util.Date. (:ctime stat))
-                                   :modified-at (java.util.Date. (:mtime stat))})))
-                   (into {})
-                   (reset! deployments)
-                   (distribute-deployment-listing send-all-fn!))
-            (Thread/sleep 1000))
-          (do
-            (println (format "Could not find deployments at %s. Retrying in 1s." zk-onyx/root-path))
-            (Thread/sleep 1000))))
-      (recur))
-    (catch org.apache.zookeeper.KeeperException$ConnectionLossException e
-      (info (format "ZK connection lost at %s. Deployments watch stopped." zk-onyx/root-path)))))
 
 (def freshness-timeout 100)
 
@@ -96,13 +69,14 @@
    (catch Throwable t
      (println "Error in process-subscription-event:" t))))
 
-(defrecord TrackTenancyManager [send-fn! peer-config tracking-id user-id]
+(defrecord TrackTenancyManager [send-fn! peer-config tracking-id user-id zk-client]
   component/Lifecycle
   (start [component]
+    (println "Starting Track Tenancy Manager")
     (let [tenancy-id (:onyx/tenancy-id peer-config)
           _ (info "Starting Track Tenancy manager for tenancy " tenancy-id peer-config user-id)
           f-check-pulses (partial deployment-pulses 
-                                  (zk/connect (:zookeeper/address peer-config)) 
+                                  zk-client 
                                   tenancy-id)
           last-replica (atom {})
           callback-fn (partial process-subscription-event 
@@ -113,15 +87,16 @@
           log-subscriber (s/start-log-subscriber peer-config {:callback-fn callback-fn})]
       (assoc component :log-subscriber log-subscriber)))
   (stop [component]
-    (info "Stopping Track Tenancy manager.")
+    (info "Stopping Track Tenancy Manager.")
     (assoc component 
            :log-subscriber (s/stop-log-subscriber (:log-subscriber component)))))
 
-(defn new-track-tenancy-manager [send-fn! peer-config user-id tracking-id]
+(defn new-track-tenancy-manager [send-fn! peer-config user-id tracking-id zk-client]
   (map->TrackTenancyManager {:send-fn! send-fn! 
                              :peer-config peer-config 
                              :user-id user-id
-                             :tracking-id tracking-id}))
+                             :tracking-id tracking-id
+                             :zk-client zk-client}))
 
 (defn stop-tracking! [tracking user-id]
   (if-let [manager (tracking user-id)]
@@ -132,7 +107,7 @@
 (defn stop-all-tracking! [tr]
   (reduce stop-tracking! tr (keys tr)))
 
-(defn start-tracking! [send-fn! peer-config tracking {:keys [deployment-id tracking-id]} user-id]
+(defn start-tracking! [send-fn! peer-config tracking {:keys [deployment-id tracking-id]} user-id zk-client]
   (try 
     (swap! tracking 
            (fn [tr]
@@ -142,6 +117,7 @@
                                   (new-track-tenancy-manager send-fn! 
                                                              (assoc peer-config :onyx/tenancy-id deployment-id)
                                                              user-id
-                                                             tracking-id))))))
+                                                             tracking-id
+                                                             zk-client))))))
     (catch Throwable t
       (println t))))

--- a/src/cljs/onyx_dashboard/components/main.cljs
+++ b/src/cljs/onyx_dashboard/components/main.cljs
@@ -13,7 +13,7 @@
             [cljs.core.async :as async :refer [<! >! put! chan]])
   (:require-macros [cljs.core.async.macros :as asyncm :refer [go-loop]]))
 
-(defcomponent main-component [{:keys [deployment metrics] :as app} owner]
+(defcomponent main-component [{:keys [deployment metrics zk-up?] :as app} owner]
   (did-mount [_] 
              (let [api-ch (om/get-shared owner :api-ch)
                    chsk-send! (om/get-shared owner :chsk-send!)] 
@@ -38,6 +38,11 @@
                                                                     :margin-top "10px"}}
                                                            "Onyx Dashboard"))))
                     (g/grid {}
+                            (when-not zk-up?
+                              (g/row {:class "no-gutter"}
+                                (g/col {:xs 12 :md 12}
+                                  (dom/div {:class "alert alert-danger"} 
+                                    "Zookeeper connection problem. Trying to reconnect..."))))
                             (g/row {:class "no-gutter"}
                                    (g/col {:xs 4 :md 4}
                                           (dom/div {:class "left-nav-deployment"} 

--- a/src/cljs/onyx_dashboard/controllers/api.cljs
+++ b/src/cljs/onyx_dashboard/controllers/api.cljs
@@ -10,6 +10,7 @@
    :time-travel-message-id nil
    :replica-states {}})
 
+; user actions
 (defmulti api-controller (fn [[cmd] _ _] cmd))
 
 (defmethod api-controller :select-job [[_ id] _ state]

--- a/src/cljs/onyx_dashboard/controllers/websocket.cljs
+++ b/src/cljs/onyx_dashboard/controllers/websocket.cljs
@@ -2,6 +2,7 @@
   (:require [clojure.set :refer [union]]
 	    [timothypratley.patchin :as p]))
 
+; update app state
 (defmulti msg-controller (fn [[type _] _] type))
 
 (defmethod msg-controller :deployment/listing 
@@ -56,6 +57,11 @@
   (if (is-tracking? msg state)
     (assoc-in state [:deployment :up?] false)
     state))
+
+(defmethod msg-controller :deployment/zk-conn-state [[_ msg] state]
+  (.log js/console "ZK connection" (str msg))
+  (assoc-in state [:zk-up?] (-> msg :zk-up?)))
+
 
 ; (defmethod msg-controller :metrics/event [[_ msg] state]
 ;   (cond (and (= (:metric msg) :throughput))

--- a/src/cljs/onyx_dashboard/core.cljs
+++ b/src/cljs/onyx_dashboard/core.cljs
@@ -17,7 +17,8 @@
 
 (defonce app-state 
   (atom {:ready? false
-         :deployments {}}))
+         :deployments {}
+         :zk-up? true}))
 
 (def packer (sente-transit/get-flexi-packer :edn))
 


### PR DESCRIPTION
- [x] Fix #54  
- [x] Fix #49  
- [x] show connection status after dashboard open
- [x] watch connection state
- [x] update connection status in dashboard
- [x] update connection status in console
- [x] close all things properly - properly reloading during dev
- [x] detect connection change very quickly
- [x] try continuously reconnect after connection lost
- [x] understand and solve problem with connection after ZK server restart

``` clojure
; when I restart ZK server
; and I continously call
(defn try-connect [client]
  (println "Trying connect ZK 5s ...")
  (.. client
      (blockUntilConnected 5 TimeUnit/SECONDS)))
; then I see continously
16-09-15 11:28:32 starter-clojure INFO [org.apache.zookeeper.ClientCnxn:975] - Opening socket connection to server 127.0.0.1/127.0.0.1:2188. Will not attempt to authenticate using SASL (unknown error)
16-09-15 11:28:32 starter-clojure INFO [org.apache.zookeeper.ClientCnxn:852] - Socket connection established to 127.0.0.1/127.0.0.1:2188, initiating session
16-09-15 11:28:32 starter-clojure DEBUG [org.apache.zookeeper.ClientCnxn:892] - Session establishment request sent on 127.0.0.1/127.0.0.1:2188
16-09-15 11:28:32 starter-clojure INFO [org.apache.zookeeper.ClientCnxn:1098] - Unable to read additional data from server sessionid 0x1572d95c4ec0006, likely server has closed socket, closing socket connection and attempting reconnect

# I don't understand why ZK is not creating new session
```
- [ ] handle connection lost from log-subscriber 

``` clojure
16-09-16 13:43:01 starter-clojure WARN [onyx.log.zookeeper:291] - Send ConnectionLossException by channel
--- entry
#error {
 :cause KeeperErrorCode = ConnectionLoss for /onyx/da248462-5adc-45b8-a3c8-6fb5516a84c4/log/entry-0000000026
 :via
 [{:type org.apache.zookeeper.KeeperException$ConnectionLossException
   :message KeeperErrorCode = ConnectionLoss for /onyx/da248462-5adc-45b8-a3c8-6fb5516a84c4/log/entry-0000000026
   :at [org.apache.zookeeper.KeeperException create KeeperException.java 99]}]
 :trace
 [[org.apache.zookeeper.KeeperException create KeeperException.java 99]
  [org.apache.zookeeper.KeeperException create KeeperException.java 51]
  [org.apache.zookeeper.ZooKeeper exists ZooKeeper.java 1045]
  [org.apache.curator.framework.imps.ExistsBuilderImpl$3 call ExistsBuilderImpl.java 226]
  [org.apache.curator.framework.imps.ExistsBuilderImpl$3 call ExistsBuilderImpl.java 215]
  [org.apache.curator.RetryLoop callWithRetry RetryLoop.java 107]
  [org.apache.curator.framework.imps.ExistsBuilderImpl pathInForegroundStandard ExistsBuilderImpl.java 211]
  [org.apache.curator.framework.imps.ExistsBuilderImpl pathInForeground ExistsBuilderImpl.java 205]
  [org.apache.curator.framework.imps.ExistsBuilderImpl forPath ExistsBuilderImpl.java 168]
  [org.apache.curator.framework.imps.ExistsBuilderImpl forPath ExistsBuilderImpl.java 39]
  [onyx.log.curator$exists invokeStatic curator.clj 141]
  [onyx.log.curator$exists doInvoke curator.clj 136]
  [clojure.lang.RestFn invoke RestFn.java 425]
  [onyx.log.zookeeper$eval25996$fn__25998$fn__26000 invoke zookeeper.clj 279]
  [clojure.core.async$thread_call$fn__8522 invoke async.clj 434]
  [clojure.lang.AFn run AFn.java 22]
  [java.util.concurrent.ThreadPoolExecutor runWorker ThreadPoolExecutor.java 1142]
  [java.util.concurrent.ThreadPoolExecutor$Worker run ThreadPoolExecutor.java 617]
  [java.lang.Thread run Thread.java 745]]}

```
- [x] handle no node exception
- [x] restart deployments watch after reconnected
