### PR TITLE
WIP: add logging into dashboard.log, allow to see logs from included jars

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,13 @@
 		 [org.omcljs/om "0.8.8"]
 		 [ankha "0.1.5.1-479897" :exclusions [om com.cemerick/austin]]
 		 [racehub/om-bootstrap "0.6.1" :exclusions [om]]
-		 [prismatic/om-tools "0.4.0" :exclusions [om]]]
+		 [prismatic/om-tools "0.4.0" :exclusions [om]]
+
+     ; usefull for debugging problems
+     ; it allows to see logs from included jars
+     ; [com.fzakaria/slf4j-timbre "0.3.2"]
+     ; [org.slf4j/log4j-over-slf4j "1.7.14"]
+     ]
 
   :plugins [[lein-cljsbuild "1.1.3"]
             ;[lein-version-spec "0.0.4"]

--- a/project.clj
+++ b/project.clj
@@ -16,6 +16,7 @@
 		 [org.clojure/clojurescript "1.8.34" :scope "provided"]
 		 [org.clojure/core.async "0.2.374"]
 		 [com.stuartsierra/component "0.3.1"]
+     [com.taoensso/timbre "4.7.4"]
 		 [com.taoensso/sente "1.8.1" :exclusions [com.taoensso/timbre com.taoensso/encore]]
                  [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
 		 [ring "1.3.2"]

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -1,0 +1,3 @@
+log4j.rootCategory=info,stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/src/clj/onyx/peer/dag_test.clj
+++ b/src/clj/onyx/peer/dag_test.clj
@@ -3,7 +3,13 @@
             [clojure.test :refer [deftest is testing]]
             [onyx.plugin.core-async :refer [take-segments!]]
             [onyx.test-helper :refer [with-test-env]]
-            [onyx.api]))
+            [onyx.api]
+            [taoensso.timbre :as timbre]))
+
+; uncomment deps from project.clj and this
+; usefull for hunting problems
+; it allows to see logs from included jars
+; (timbre/set-level! :trace)
 
 (def n-messages 15000)
 

--- a/src/clj/onyx_dashboard/system.clj
+++ b/src/clj/onyx_dashboard/system.clj
@@ -15,8 +15,21 @@
             [ring.middleware.reload :as reload]
             [environ.core :refer [env]]
             [onyx.static.validation :refer [validate-peer-config]]
-            [clojure.string :refer [upper-case]])
+            [clojure.string :refer [upper-case]]
+            [taoensso.timbre :refer [info] :as timbre]
+            [taoensso.timbre.appenders.3rd-party.rotor :as rotor])
   (:gen-class))
+
+; uncomment some deps from project.clj to see also logs from included jars
+(let [file-log-lvl    :error   ; set to :trace to see more details
+      console-log-lvl :info
+      rotor-appender (rotor/rotor-appender {:path "dashboard.log"})
+      rotor-appender (assoc rotor-appender :min-level file-log-lvl)]
+      (timbre/merge-config!
+          {:appenders
+            {:println {:min-level console-log-lvl
+                       :enabled? true}
+             :rotor rotor-appender}}))
 
 (defn get-system 
   ([zookeeper-addr]


### PR DESCRIPTION
Fix #65 - it allows to display logging messages from included jars  - needs uncomment deps from project.clj. Usefull for problems hunting and debugging.
Fix #38 - logging into dashboard.log file


