### PR TITLE
Fix logging from included jars

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,15 +16,21 @@
 		 [org.clojure/clojurescript "1.8.34" :scope "provided"]
 		 [org.clojure/core.async "0.2.374"]
 		 [com.stuartsierra/component "0.3.1"]
-     [com.taoensso/timbre "4.7.4"]
-		 [com.taoensso/sente "1.8.1" :exclusions [com.taoensso/timbre com.taoensso/encore]]
-                 [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
+     ; taoensso deps
+     [com.taoensso/timbre "4.7.4" ]
+     [com.taoensso/encore "2.67.2"]
+     [com.taoensso/sente  "1.8.1" :exclusions [com.taoensso/timbre com.taoensso/encore]]
+
+     [com.lucasbradstreet/cljs-uuid-utils "1.0.2"]
 		 [ring "1.3.2"]
 		 ^{:voom {:repo "git@github.com:onyx-platform/onyx.git" :branch "master"}}
-		 [org.onyxplatform/onyx "0.9.10"]
-		 [org.onyxplatform/lib-onyx "0.9.7.1" :exclusions [ring-jetty-component org.onyxplatform/onyx]]
-                 [org.onyxplatform/onyx-visualization "0.4.0"]
-		 [timothypratley/patchin "0.3.5"]
+		 
+     ; onyx deps
+     [org.onyxplatform/onyx               "0.9.10"  :exclusions [org.slf4j/slf4j-nop]]
+     [org.onyxplatform/lib-onyx           "0.9.7.1" :exclusions [ring-jetty-component org.onyxplatform/onyx]]
+     [org.onyxplatform/onyx-visualization "0.4.0"]
+		 
+     [timothypratley/patchin "0.3.5"]
 		 [com.cognitect/transit-clj "0.8.285"]
 		 [com.cognitect/transit-cljs "0.8.237"]
 		 [cljsjs/moment "2.9.0-0"]
@@ -76,8 +82,11 @@
                    :dependencies [[figwheel "0.5.0-6"]
                                   [org.seleniumhq.selenium/selenium-java "2.47.1"]
                                   [clj-webdriver "0.7.2"]
-                                  [com.fzakaria/slf4j-timbre "0.3.2"]
+                                  ; logging from included jars
+                                  [com.fzakaria/slf4j-timbre  "0.3.2"]
+                                  [org.slf4j/slf4j-api        "1.7.14"]
                                   [org.slf4j/log4j-over-slf4j "1.7.14"]
+                                  
                                   [leiningen "2.6.1"]]
 
                    :repl-options {:init-ns onyx-dashboard.system

--- a/src/clj/onyx_dashboard/system.clj
+++ b/src/clj/onyx_dashboard/system.clj
@@ -16,23 +16,22 @@
             [environ.core :refer [env]]
             [onyx.static.validation :refer [validate-peer-config]]
             [clojure.string :refer [upper-case]]
-            [taoensso.timbre :refer [info] :as timbre]
+            [taoensso.timbre :as timbre]
             [taoensso.timbre.appenders.3rd-party.rotor :as rotor])
   (:gen-class))
 
-; uncomment some deps from project.clj to see also logs from included jars
-(let [file-log-lvl    :error   ; set to :trace to see more details
-      console-log-lvl :info
-      rotor-appender (rotor/rotor-appender {:path "dashboard.log"})
-      rotor-appender (assoc rotor-appender :min-level file-log-lvl)]
-      (timbre/merge-config!
-          {:appenders
-            {:println {:min-level console-log-lvl
-                       :enabled? true}
-             :rotor rotor-appender}}))
 
 (defn get-system 
   ([zookeeper-addr]
+    (let [file-log-lvl    :error   ; set to :trace to see more details
+          console-log-lvl :info
+          rotor-appender (rotor/rotor-appender {:path "dashboard.log"})
+          rotor-appender (assoc rotor-appender :min-level file-log-lvl)]
+          (timbre/merge-config!
+              {:appenders
+                {:println {:min-level console-log-lvl
+                           :enabled? true}
+                 :rotor rotor-appender}}))
    (component/system-map
      :sente (component/using (sente) [])
      :http (component/using (new-http-server {:zookeeper/address zookeeper-addr


### PR DESCRIPTION
Resolve #65.  I had to exclude `org.slf4j/slf4j-nop`. This caused that `slf4j-timbre` wasn't picked up to work. 