### PR TITLE
Environment variable "DISABLE_MANAGEMENT" disables kill button

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ docker run -p 3000:3000 onyx/onyx-dashboard:<tag> 192.168.1.170:2188
 
 The IP passed in is used by ZooKeeper.
 
+You may optionally pass in the environment variable "DISABLE_MANAGEMENT" with the value of "true" to disable the ability to kill jobs via the dashboard.
+
 NOTE: If you are running the Onyx Dashboard via Docker on Mac, but are running ZooKeeper locally, be aware
 that there are limitations with networking on Mac. Per the [Docker on Mac networking documentation](https://docs.docker.com/docker-for-mac/networking/),
 your best work around is to assign a dummy IP as an alias to the loopback adapter on the host machine

--- a/env/dev/clj/onyx_dashboard/dev.clj
+++ b/env/dev/clj/onyx_dashboard/dev.clj
@@ -6,6 +6,7 @@
             [leiningen.core.main :as lein]))
 
 (def is-dev? (env :is-dev))
+(def disable-management? (= "true" (env :disable-management)))
 
 (def inject-devmode-html
   (comp

--- a/env/prod/clj/onyx_dashboard/dev.clj
+++ b/env/prod/clj/onyx_dashboard/dev.clj
@@ -7,6 +7,7 @@
                           "Remove the target/ directory and try again."))))
 
 (def is-dev? false)
+(def disable-management? (= "true" (env :disable-management)))
 (def inject-devmode-html identity)
 (defn browser-repl []
   (throw (Exception. "Browser connected REPL is not available in prod mode")))

--- a/src/clj/onyx_dashboard/http/deployments.clj
+++ b/src/clj/onyx_dashboard/http/deployments.clj
@@ -1,6 +1,7 @@
 (ns onyx-dashboard.http.deployments
   (:require [clojure.core.async :refer [close! chan go-loop <!]]
             [com.stuartsierra.component :as component]
+            [onyx-dashboard.dev :refer [disable-management?]]
             [onyx.log.curator           :as zk]
             [onyx.log.zookeeper         :as zk-onyx]))
 
@@ -22,7 +23,8 @@
                                 (partial zk-deployment-entry-stat zk-client)))
                      (map (fn [[child stat]]
                             (vector child
-                                    {:created-at  (java.util.Date. (:ctime stat))
+                                    {:manageable? (not disable-management?)
+                                     :created-at  (java.util.Date. (:ctime stat))
                                      :modified-at (java.util.Date. (:mtime stat))})))
                      (into {})
                      (reset! deployments)

--- a/src/cljs/onyx_dashboard/components/main.cljs
+++ b/src/cljs/onyx_dashboard/components/main.cljs
@@ -54,7 +54,7 @@
                                                          :last-entry (sq/deployment->latest-entry deployment)})
                                               (om/build job-selector deployment {})
                                               (om/build deployment-peers deployment {})
-                                               (if job
+                                               (if (and job (:manageable? job))
                                                  (om/build job-management
                                                            {:replica (sq/deployment->latest-replica deployment)
                                                             :job-info job}


### PR DESCRIPTION
A different approach than #85, using an environment variable to disable the kill button for jobs.

**DISCLAIMER**: I haven't tested any of this yet. Just wanted to see if there were any differing opinions about how this should be implemented.